### PR TITLE
Squash merge feature/DLOB-1750-nexttrainnumber-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
     - Spezifikation für timeTableArrivalTime timeTableDepartureTime angepasst. 
 - **v2.3.2** 
     - Enum-Wert für Jahresfahrplan behoben. 
- - **v2.4.0** 
-    - Unterstützung des Zug-Verbindungstyps 'Durchbinden' hinzugefügt.                 
-    
+- **v2.4.0** 
+    - Unterstützung des Zug-Verbindungstyps 'Durchbinden' hinzugefügt.                  
+- **v2.4.1** 
+    - 'train' aus nextTrainNumber und nextTrainLinkType entfernt, weil es redundant ist.
+    - nextPiNumber hinzugefügt                 
+         
 ### English
 - **v0.1.1**
     - Initial version.
@@ -75,5 +78,8 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
     - Specified timeTableArrivalTime and timeTableDepartureTime more precise.
 - **v2.3.2**  
     - Fixed enum value for period schedule
- - **v2.4.0** 
+- **v2.4.0** 
     - Added support for train link type 'continuation'.                 
+- **v2.4.1** 
+    - removed 'train' from nextTrainNumber and nextTrainLinkType because it is redundant
+    - added nextPiNumber 

--- a/djsf.json
+++ b/djsf.json
@@ -2,7 +2,7 @@
 	"type":"object",
 	"$schema": "http://json-schema.org/draft-03/schema",
 	"id": "http://diloc.de/djsf",
-	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.4",
+	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.4.1",
 	"required":false,
 	"properties":{
 		"meta":{
@@ -286,16 +286,22 @@
 
 
 						},
-						"nextTrainNumber": {
+						"nextNumber": {
 							"type":"string",
-							"description": "The number of the next train in case the train returns as another train number. This can be used to directly select the next train when the train arrives at its destination station.",
-							"id": "#nextTrainNumber",
+							"description": "The number of the next train in case the train returns as another train number. This can be used to directly select the next train when the train arrives at its destination station. This can also be used to define a continuation, when another train number continue the trip.",
+							"id": "#nextNumber",
 							"required":false
 						},
-						"nextTrainLinkType": {
+                        "nextPiNumber": {
+                          "type":"string",
+                          "description": "The pi number of the next train.",
+                          "id": "#nextPiNumber",
+                          "required":false
+                        },
+						"nextLinkType": {
 							"type":"array",
 							"description": "Defines the link type of two train numbers.",
-							"id": "#nextTrainLinkType",
+							"id": "#nextLinkType",
 							"required":false,
 							"items": {
 								"enum":["circular", "continuation"],


### PR DESCRIPTION
## Fixes
Removed 'train' from nextTrainNumber and nextTrainLinkType because it is redundant and added nextPiNumber.

