### PR TITLE
Squash merge feature/DLOB-2977-add-timestamp-property-for-the-djsf-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
     - 'train' aus nextTrainNumber und nextTrainLinkType entfernt, weil es redundant ist.
     - nextPiNumber hinzugefügt  
 - **v2.4.2**
-    - timestamp hinzugefügt für neu generiert Jahresfahrplan.
+    - createdAt für Erzeugungszeitpunkt des Fahrplans hinzugefügt.
          
 ### English
 - **v0.1.1**
@@ -86,4 +86,4 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
     - removed 'train' from nextTrainNumber and nextTrainLinkType because it is redundant
     - added nextPiNumber 
 - **v2.4.2**
-    - added 'timestamp' for the new generated period schedule.
+    - Added 'createdAt' which represents the generation timestamp of the schedule.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
     - Unterstützung des Zug-Verbindungstyps 'Durchbinden' hinzugefügt.                  
 - **v2.4.1** 
     - 'train' aus nextTrainNumber und nextTrainLinkType entfernt, weil es redundant ist.
-    - nextPiNumber hinzugefügt                 
+    - nextPiNumber hinzugefügt  
+- **v2.4.2**
+    - timestamp hinzugefügt für neu generiert Jahresfahrplan.
          
 ### English
 - **v0.1.1**
@@ -83,3 +85,5 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
 - **v2.4.1** 
     - removed 'train' from nextTrainNumber and nextTrainLinkType because it is redundant
     - added nextPiNumber 
+- **v2.4.2**
+    - added 'timestamp' for the new generated period schedule.

--- a/djsf.json
+++ b/djsf.json
@@ -2,7 +2,7 @@
 	"type":"object",
 	"$schema": "http://json-schema.org/draft-03/schema",
 	"id": "http://diloc.de/djsf",
-	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.4.1",
+	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.4.2",
 	"required":false,
 	"properties":{
 		"meta":{
@@ -37,6 +37,11 @@
 					"description": "The type of the generated schedule (\"period\" or \"day\").",
 					"id": "#scheduletype",
 					"required":true
+				},
+				"timestamp": {
+					"type":"string",
+					"required":true,
+					"description": "The timestamp when the period schedule is generated."
 				}
 			}
 		},

--- a/djsf.json
+++ b/djsf.json
@@ -38,10 +38,11 @@
 					"id": "#scheduletype",
 					"required":true
 				},
-				"timestamp": {
+				"createdAt": {
 					"type":"string",
+					"format":"date-time",
 					"required":true,
-					"description": "The timestamp when the period schedule is generated."
+					"description": "The timestamp when the schedule is created in ISO-8601 format. For example: 2022-12-02T10:20:39+00:00"
 				}
 			}
 		},


### PR DESCRIPTION
## timestamp

Added timestamp property for the DJSF-Spec:
- Added 'createdAt' which represents the generation timestamp of the schedule.