### PR TITLE
Merge feature/DLOB-4101-add-externalIdentifier-field-to-routeStationIdentifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ This repository contains all information about the **D**iLoc**J**son**S**chedule
         - Added "display_interior" and "display_exterior" in script track type enum.
 - **v2.5.0**
     - Added 'specialAnnouncements' property to the JSON schema.
+- **v2.5.1**
+    - Added 'externalIdentifier' property to routeStationIdentifier.

--- a/djsf.json
+++ b/djsf.json
@@ -2,7 +2,7 @@
 	"type":"object",
 	"$schema": "http://json-schema.org/draft-03/schema",
 	"id": "http://diloc.de/djsf",
-	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.5.0",
+	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.5.1",
 	"required":false,
 	"properties":{
 		"meta":{

--- a/djsf.json
+++ b/djsf.json
@@ -565,7 +565,7 @@
 				},
 				"externalIdentifier": {
 					"type": "string",
-					"description": "A unique identifier for the station, formed by concatenating the station's idCode with the train's arrival track number. For example, APPZ_1.",
+					"description": "A unique identifier for the station, this could be any external identifier, for example the REC_ORT number of a VDV452 schedule Import.",
 					"id": "#externalIdentifier",
 					"required": false
 				}

--- a/djsf.json
+++ b/djsf.json
@@ -562,6 +562,12 @@
 					"description": "The sequence number of the station on the route.",
 					"id": "#sequenceNumber",
 					"required":true
+				},
+				"externalIdentifier": {
+					"type": "string",
+					"description": "A unique identifier for the station, formed by concatenating the station's idCode with the train's arrival track number. For example, APPZ_1.",
+					"id": "#externalIdentifier",
+					"required": false
 				}
 			}
 		},


### PR DESCRIPTION
- Added externalIdentifier property to train.routeStationIdentifier object.
- Bumped schema version to 2.5.1