### PR TITLE
Merge fix/DLOB-5292-add-trainNumber-param-to-showDestination-schedule-command

### DIFF
--- a/djsf.json
+++ b/djsf.json
@@ -486,6 +486,11 @@
 							"type":"string",
 							"minItems":0
 						}
+					},
+					"trainNumber":{
+						"type":"string",
+						"required":false,
+						"description":"The number of the train. This may contain alphanumeric symbols and dots."
 					}
 				}
 			},


### PR DESCRIPTION
Added trainNumber parameter to #/definitions/params/showDestination