### PR TITLE
Squash feature/DLOB-5946-adapt-fileDownloadUrl-example-url

### DIFF
--- a/djsf.json
+++ b/djsf.json
@@ -47,7 +47,7 @@
 				"fileDownloadUrl": {
 					"type":"string",
 					"required":false,
-					"description": "The URL with path to the API endpoint to download schedule audio files. The file path and mpi device id code are added as query parameter. Example: https://onboard.diloc.de/capsules/fleetmanager/getScheduleAudioFile/?filePath=abc/a.mp3&mpiDeviceIdCode=test"
+					"description": "The URL with path to the API endpoint to download schedule audio files. The file path and mpi device id code are added as query parameter. Example: https://api.example.com/schedules/audio/download?filePath=abc/a.mp3&mpiDeviceIdCode=test"
 				}
 			}
 		},


### PR DESCRIPTION
- Our onboard server url is hardcoded in the example param and is for public available under: https://cn-mobility.eu/de/djsf.
- I changed this to use an example url