### PR TITLE
Squash feature/IT-2931-json-schema-draft-4

### DIFF
--- a/djsf.json
+++ b/djsf.json
@@ -207,7 +207,6 @@
 
 										},
 										"routeStationIdentifier": {
-                                            "title": "routeStationIdentifier",
 											"$ref":"#/definitions/routeStationIdentifier"
 										},
 										"stopType": {
@@ -269,8 +268,6 @@
                                                 "description": "Contains commands that should be sent to the output when the train is activated by the driver.",
                                                 "id": "#startCommands",
                                                 "items":{
-                                                    "title": "startCommand",
-                                                    "type":"object",
                                                     "$ref":"#/definitions/command"
                                                 }
                                             },
@@ -289,13 +286,10 @@
                                                             "id": "#commands",
                                                             "items":
                                                             {
-                                                                "title": "command",
-                                                                "type":"object",
                                                                 "$ref":"#/definitions/command"
                                                             }
                                                         },
                                                         "routeStationIdentifier": {
-                                                            "title": "routeStationIdentifier",
                                                             "$ref":"#/definitions/routeStationIdentifier"
                                                         }
                                                     }
@@ -349,8 +343,6 @@
 							"id": "#multiTractionTrains",
 							"minItems": 0,
 							"items":{
-                                "title": "multiTractionTrain",
-								"type":"object",
 								"$ref":"#/definitions/multiTractionTrains"
 							}
 						}

--- a/djsf.json
+++ b/djsf.json
@@ -1,6 +1,6 @@
 {
 	"type":"object",
-	"$schema": "http://json-schema.org/draft-03/schema",
+    "$schema": "https://json-schema.org/draft-04/schema#",
 	"id": "http://diloc.de/djsf",
 	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.5.2",
 	"required":false,

--- a/djsf.json
+++ b/djsf.json
@@ -54,7 +54,7 @@
 		"files": {
 			"type": "array",
 			"description": "Contains a list of all files in the schedule and those essential for special announcements.",
-			"minitems": "0",
+			"minItems": 0,
 			"id": "http://diloc.de/djsf/files",
 			"required":true,
 			"items": {
@@ -84,7 +84,7 @@
 		"trains": {
 			"type":"array",
 			"description": "Contains a list of all trains in the schedule.",
-			"minitems": "1",
+			"minItems": 1,
 			"id": "http://diloc.de/djsf/trains",
 			"required":true,
 			"items":
@@ -130,7 +130,7 @@
 						"routeStations": {
 							"type":"array",
 							"description": "Contains all stations the train will travel.",
-							"minitems": "2",
+							"minItems": 2,
 							"id": "http://diloc.de/djsf/train/routeStations",
 							"required":true,
 							"items":
@@ -339,7 +339,7 @@
 							"description": "This could be null, an empty array or an array of objects. Null means that this trains does not have any multitraction partner. An empty array means that this trains is a multitraction partner for another leading train. And an array of objects means that this train has multitraction partner and it's the leading train. The order of the trains in the array defines the order of trains in the multitraction.",
 							"id": "#multiTractionTrains",
 							"required":false,
-							"minitems": 0,
+							"minItems": 0,
 							"items":[{
 								"type":"object",
 								"$ref":"#/definitions/multiTractionTrains"
@@ -351,7 +351,7 @@
 		"specialAnnouncements": {
 			"type":"array",
 			"description": "Contains a list of special announcements",
-			"minitems": "0",
+			"minItems": 0,
 			"id": "http://diloc.de/djsf/specialAnnouncements",
 			"required":true,
 			"items": {

--- a/djsf.json
+++ b/djsf.json
@@ -414,6 +414,7 @@
     "definitions":{
 		"command":{
             "title": "command",
+            "type":"object",
 			"required":["name", "on"],
 			"properties":{
 				"name": {

--- a/djsf.json
+++ b/djsf.json
@@ -545,7 +545,8 @@
                         "title": "playList",
 						"type":"array",
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
-						"items":{
+						"minItems": 1,
+                        "items":{
                             "title": "fileName",
 							"type":"string",
 							"description":"A filename that should be played. This has to match with the filePath of one file in the files array of the schedule."
@@ -820,7 +821,7 @@
                         "title": "playList",
 						"type":"array",
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
-						"minItems":1,
+						"minItems": 1,
                         "items":{
                             "title": "fileName",
 							"type":"string",

--- a/djsf.json
+++ b/djsf.json
@@ -2,49 +2,58 @@
 	"type":"object",
     "$schema": "https://json-schema.org/draft-04/schema#",
 	"id": "http://diloc.de/djsf",
+    "title":"DiLoc JSON Schedule Format",
 	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.5.2",
 	"required":false,
 	"properties":{
 		"meta":{
+            "title":"meta",
 			"type":"object",
 			"required":true,
 			"description":"Contains meta-information about the schedule.",
 			"properties":{
 				"validFrom":{
+                    "title":"validFrom",
 					"type":"string",
 					"format":"date-time",
 					"required":true,
 					"description":"The date-time from when the schedule is valid."
 				},
 				"validTo":{
+                    "title":"validTo",
 					"type":"string",
 					"format":"date-time",
 					"required":true,
 					"description":"The date-time until this schedule is valid."
 				},
 				"version":{
+                    "title":"version",
 					"type":"string",
 					"required":true,
 					"description":"The version describes the version of the schedule. The version usually starts with 1.0 and is increased for newer versions 1.1, 1.2, etc)"
 				},
 				"djsfSchemaVersion":{
+                    "title":"djsfSchemaVersion",
 					"type":"string",
 					"required":true,
 					"description":"The version describes the djsf schema version of the generated schedule."
 				},
 				"type": {
+                    "title":"type",
 					"enum":["period","day"],
 					"description": "The type of the generated schedule (\"period\" or \"day\").",
 					"id": "#scheduletype",
 					"required":true
 				},
 				"createdAt": {
+                    "title":"createdAt",
 					"type":"string",
 					"format":"date-time",
 					"required":true,
 					"description": "The timestamp when the schedule is created in ISO-8601 format. For example: 2022-12-02T10:20:39+00:00"
 				},
 				"fileDownloadUrl": {
+                    "title":"fileDownloadUrl",
 					"type":"string",
 					"required":false,
 					"description": "The URL with path to the API endpoint to download schedule audio files. The file path and mpi device id code are added as query parameter. Example: https://api.example.com/schedules/audio/download?filePath=abc/a.mp3&mpiDeviceIdCode=test"
@@ -52,28 +61,33 @@
 			}
 		},
 		"files": {
+            "title": "files",
 			"type": "array",
 			"description": "Contains a list of all files in the schedule and those essential for special announcements.",
 			"minItems": 0,
 			"id": "http://diloc.de/djsf/files",
 			"required":true,
 			"items": {
+                "title": "file",
 				"type":"object",
 				"description": "The file object contains all information about the file to find it in the schedule-file or download it from the DiLoc-Server.",
 				"id": "http://diloc.de/djsf/file",
 				"required":false,
 				"properties": {
 					"filePath": {
+                        "title": "filePath",
 						"type": "string",
 						"required": true,
 						"description": "The path to the file (including filename) relative to the files folder in the schedule file. This path is used in the playList of the enqueueFiles command."
 					},
 					"type": {
+                        "title": "type",
 						"enum":["audio","image","video"],
 						"description": "The type of the file.",
 						"required":true
 					},
 					"md5Checksum": {
+                        "title": "md5Checksum",
 						"type": "string",
 						"required": true,
 						"description": "The md5 checksum of the file."
@@ -82,6 +96,7 @@
 			}
 		},
 		"trains": {
+            "title": "trains",
 			"type":"array",
 			"description": "Contains a list of all trains in the schedule.",
 			"minItems": 1,
@@ -89,36 +104,42 @@
 			"required":true,
 			"items":
 				{
+                    "title":"train",
 					"type":"object",
 					"description": "The train object contains all information about a train.",
 					"id": "http://diloc.de/djsf/train",
 					"required":false,
 					"properties":{
 						"trainNumber": {
+                            "title": "trainNumber",
 							"type":"string",
 							"description": "The number of the train. This may contain alphanumeric symbols and dots.",
 							"id": "http://diloc.de/djsf/trains/0/trainNumber",
 							"required":false
 						},
 						"piNumber": {
+                            "title": "piNumber",
 							"type":"string",
 							"description": "The pi number of the train. This may contain alphanumeric symbols and dots.",
 							"id": "http://diloc.de/djsf/trains/0/piNumber",
 							"required":false
 						},
 						"departureTime": {
+                            "title": "departureTime",
 							"type":"string",
 							"description": "The departure time of the train in H:i:s format.",
 							"id": "#departureTime",
 							"required":true
 						},
 						"product": {
+                            "title": "product",
 							"type":"object",
 							"description": "The product information about a train.",
 							"id": "#product",
 							"required":false,
 							"properties":{
 								"name": {
+                                    "title": "name",
 									"type":"string",
 									"description": "The product name.",
 									"id": "#name",
@@ -128,6 +149,7 @@
 						},
 
 						"routeStations": {
+                            "title": "routeStations",
 							"type":"array",
 							"description": "Contains all stations the train will travel.",
 							"minItems": 2,
@@ -135,23 +157,27 @@
 							"required":true,
 							"items":
 								{
+                                    "title": "routeStation",
 									"type":"object",
 									"required":true,
 									"id": "http://diloc.de/djsf/train/routeStations",
 									"properties":{
 										"connections": {
+                                            "title": "connections",
 											"type":"array",
 											"description": "An array of connections that should be displayed at this station.",
 											"id": "#connections",
 											"required":false,
 											"items":
 												{
+                                                    "title": "connection",
 													"type":"object",
 													"description": "Contains information about a connection at the station.",
 													"id": "#connection",
 													"required":false,
 													"properties":{
 														"category": {
+                                                            "title": "category",
 															"type":"string",
 															"enum":["underground","citytrain","tram","bus","localtraffic","longdistancetraffic"],
 															"description": "This gives information about how the train should be displayed.",
@@ -159,36 +185,42 @@
 															"required":true
 														},
 														"departureTime": {
+                                                            "title": "departureTime",
 															"type":"string",
 															"description": "The time when the connected train/bus etc. departs",
 															"id": "#departureTime",
 															"required":true
 														},
 														"destination": {
+                                                            "title": "destination",
 															"type":"string",
 															"description": "The destination the connected product travels to.",
 															"id": "#destination",
 															"required":true
 														},
 														"line": {
+                                                            "title": "line",
 															"type":"string",
 															"description": "The line of the connected product. For example: 201",
 															"id": "#line",
 															"required":false
 														},
 														"note": {
+                                                            "title": "note",
 															"type":"string",
 															"description": "A note containing additional information about the connection.",
 															"id": "#note",
 															"required":false
 														},
 														"platform": {
+                                                            "title": "platform",
 															"type":"string",
 															"description": "The platform at which the connected product departs.Examples for this are 1, A or 3A. ",
 															"id": "#platform",
 															"required":false
 														},
 														"product": {
+                                                            "title": "product",
 															"type":"string",
 															"description": "The name of the product like 'S12' or 'IC', 'IR', etc. Depending on the content it may be necessary to display a pictogram of the given product. For example for the product IC, IR there are special pictograms in Switzerland that should be displayed in this case.",
 															"id": "#product",
@@ -200,21 +232,25 @@
 
 										},
 										"routeStationIdentifier": {
+                                            "title": "routeStationIdentifier",
 											"$ref":"#/definitions/routeStationIdentifier"
 										},
 										"stopType": {
+                                            "title": "stopType",
 											"enum":["departure","conditionalHalt","passthrough","technical","exitOnly","arrival", "halt"],
 											"description": "The type of the stop.",
 											"id": "#stopType",
 											"required":true
 										},
 										"timeTableArrivalTime": {
+                                            "title": "timeTableArrivalTime",
 											"type":"number",
 											"description": "The time table arrival time in seconds after the departure of the train. The order of the routeStations must be ascending over timeTableArrivalTime.",
 											"id": "#timeTableArrivalTime",
 											"required":false
 										},
 										"timeTableDepartureTime": {
+                                            "title": "timeTableDepartureTime",
 											"type":"number",
 											"description": "The time table departure time in seconds after the departure of the train. If stopType equals 'passthrough' the timeTableDepartureTime must be the same like timeTableArrivalTime.",
 											"id": "#timeTableDepartureTime",
@@ -226,65 +262,77 @@
 
 						},
 						"script": {
+                            "title": "script",
 							"type":"object",
 							"description": "The script contains all necessary information to drive the passenger information for this train.",
 							"id": "http://diloc.de/djsf/train/script",
 							"required":false,
 							"properties":{
 								"tracks": {
+                                    "title": "tracks",
 									"type":"array",
 									"description": "A track contains the information what a specific output device in the train should do.",
 									"id": "http://diloc.de/djsf/train/script/tracks",
 									"required":true,
 									"items":[
 										{
+                                            "title": "track",
 											"type":"object",
 											"id": "http://diloc.de/djsf/trains/script/track",
 											"required":false,
 											"properties":{
 												"type": {
+                                                    "title": "type",
 													"enum":["led","tft","audio","display_interior","display_exterior"],
 													"description":"The type of track.",
 													"id": "#type",
 													"required":false
 												},
 												"identifier": {
+                                                    "title": "identifier",
 													"type":"string",
 													"description": "The identifier that identifies the channel. This is unique per script.",
 													"id": "#identifier",
 													"required":true
 												},
 												"startCommands": {
+                                                    "title": "startCommands",
 													"type":"array",
 													"description": "Contains commands that should be sent to the output when the train is activated by the driver.",
 													"id": "#startCommands",
 													"required":true,
 													"items":[{
+                                                        "title": "startCommand",
 														"type":"object",
 														"$ref":"#/definitions/command"
 													}]
 												},
 												"stations": {
+                                                    "title": "stations",
 													"type":"array",
 													"id": "#stations",
 													"required":false,
 													"items":[
 														{
+                                                            "title": "station",
 															"type":"object",
 															"id": "#station",
 															"required":false,
 															"properties":{
 																"commands": {
+                                                                    "title": "commands",
 																	"type":"array",
 																	"id": "#commands",
 																	"required":false,
 																	"items":
 																	{
+                                                                        "title": "command",
 																		"type":"object",
 																		"$ref":"#/definitions/command"
 																	}
 																},
 																"routeStationIdentifier": {
+                                                                    "title": "routeStationIdentifier",
 																	"$ref":"#/definitions/routeStationIdentifier"
 																}
 															}
@@ -298,12 +346,14 @@
 							}
 						},
 						"travelsOnDays": {
+                            "title": "travelsOnDays",
 							"type":"array",
 							"description": "This defines on which days the train travels. This only applies for period schedules. On day schedules only the trains that really travel on the day are included in the schedule.",
 							"id": "#travelsOnDays",
 							"required":false,
 							"items":
 								{
+                                    "title": "day",
 									"enum":["mo","th","tu","we","fr","sa","su"],
 									"description": "The days the train travels. ",
 									"required":false
@@ -312,35 +362,41 @@
 
 						},
 						"nextNumber": {
+                            "title": "nextNumber",
 							"type":"string",
 							"description": "The number of the next train in case the train returns as another train number. This can be used to directly select the next train when the train arrives at its destination station. This can also be used to define a continuation, when another train number continue the trip.",
 							"id": "#nextNumber",
 							"required":false
 						},
                         "nextPiNumber": {
+                            "title": "nextPiNumber",
                           "type":"string",
                           "description": "The pi number of the next train.",
                           "id": "#nextPiNumber",
                           "required":false
                         },
 						"nextLinkType": {
+                            "title": "nextLinkType",
 							"type":"array",
 							"description": "Defines the link type of two train numbers.",
 							"id": "#nextLinkType",
 							"required":false,
 							"items": {
+                                "title": "linkType",
 								"enum":["circular", "continuation"],
 								"description": "Circular defines the link type for regular circulation trips. Continuation defines a link type for a train which does not circulate at the destination station.",
 								"required":false
 							}
 						},
 						"multiTractionTrains" : {
+                            "title": "multiTractionTrains",
 							"type":"array",
 							"description": "This could be null, an empty array or an array of objects. Null means that this trains does not have any multitraction partner. An empty array means that this trains is a multitraction partner for another leading train. And an array of objects means that this train has multitraction partner and it's the leading train. The order of the trains in the array defines the order of trains in the multitraction.",
 							"id": "#multiTractionTrains",
 							"required":false,
 							"minItems": 0,
 							"items":[{
+                                "title": "multiTractionTrain",
 								"type":"object",
 								"$ref":"#/definitions/multiTractionTrains"
 							}]
@@ -349,12 +405,14 @@
 				}
 		},
 		"specialAnnouncements": {
+            "title": "specialAnnouncements",
 			"type":"array",
 			"description": "Contains a list of special announcements",
 			"minItems": 0,
 			"id": "http://diloc.de/djsf/specialAnnouncements",
 			"required":true,
 			"items": {
+                "title": "specialAnnouncement",
 				"minItems":0,
 				"type":"object",
 				"description": "The specialAnnouncement encapsulates details and data of a special announcement",
@@ -362,31 +420,36 @@
 				"required":false,
 				"properties": {
 					"name": {
+                        "title": "name",
 						"type": "string",
 						"required": true,
 						"description": "The short name of the specialAnnouncement."
 					},
 					"description": {
+                        "title": "description",
 						"type": "string",
 						"required": true,
 						"description": "The description of the specialAnnouncement."
 					},
 					"number": {
+                        "title": "number",
 						"type": "integer",
 						"required": true,
 						"description": "The number of the specialAnnouncement used mainly to easily find/identify a specialAnnouncement by the driver. This musst be a unique number."
 					},
 					"sortOrder": {
+                        "title": "sortOrder",
 						"type": "integer",
 						"required": false,
 						"description": "An optional property that can be used by DiLoc|OnBoard to defines the order in which special announcements are arranged"
 					},
 					"commands": {
+                        "title": "commands",
 						"type": "array",
 						"required": true,
 						"description": "An array of commands that the specialAnnouncement will execute when it is activated",
 						"items":[{
-							"required":false,
+                            "title": "command",
 							"type":"object",
 							"description": "The parameters for the command. Parameters are command specific. So each command-type has different parameters.",
 							"anyOf":[
@@ -404,26 +467,30 @@
 	},
 	"definitions":{
 		"command":{
-			"required":false,
+            "title": "command",
 			"properties":{
 				"name": {
+                    "title": "name",
 					"type":"string",
 					"description": "The name of the command that should be sent.",
 					"id": "http://diloc.de/djsf/trains/0/script/tracks/0/startCommands/0/name",
 					"required":true
 				},
 				"on": {
+                    "title": "on",
 					"type":["integer", "string"],
 					"description": "Describes where the action should be executed. This can either be a negative number like -100 or one of the fixed strings 'halt' and 'start'. Number are interpreted as meters before/after the station. 'halt' means when the train halts at the given station. 'start' means when the train starts and should be used inside startCommands. For pre announcements, this should contain 'plannedDepartureTime'",
 					"id": "http://diloc.de/djsf/trains/0/script/tracks/0/startCommands/0/name",
 					"required":true
 				},
 				"timeOffset": {
+                    "title": "timeOffset",
 					"type": ["integer"],
 					"description": "This is required, if parameter 'on' is 'planneddeparturetime'. This should contain for example '-100' to trigger an announcement hundred seconds before planned departure time.",
 					"required": false
 				},
 				"params": {
+                    "title": "params",
 					"type":"object",
 					"description": "The parameters for the command. Parameters are command specific. So each command-type has different parameters.",
 					"id": "http://diloc.de/djsf/definitions/params",
@@ -445,49 +512,61 @@
 			}
 		},
 		"params":{
+            "title": "params",
 			"showPearlChain":{
+                "title": "showPearlChain",
 				"type":"object",
 				"description":"The showPearlChain-command has no parameters."
 			},
 			"showConnections":{
+                "title": "showConnections",
 				"type":"object",
 				"description":"The showConnections-command has no parameters."
 			},
 			"showEmpty":{
+                "title": "showEmpty",
 				"type":"object",
 				"description":"The showEmpty-command has no parameters."
 			},
 			"showBlack":{
+                "title": "showBlack",
 				"type":"object",
 				"description":"The showBlack-command has no parameters."
 			},
 			"showMessage":{
+                "title": "showMessage",
 				"type":"object",
 				"description":"The parameters of the showMessage-command are still TBD."
 			},
 			"showDestination":{
+                "title": "showDestination",
 				"type":"object",
 				"properties":{
 					"line": {
+                        "title": "line",
 						"type":"string",
 						"required":false,
 						"description":"The line that should be displayed. For example 'S21'."
 					},
 					"destination":{
+                        "title": "destination",
 						"type":"string",
 						"required":true,
 						"description":"The name of the destination station that should be displayed."
 					},
 					"via":{
+                        "title": "via",
 						"type":"array",
 						"required":false,
 						"description":"The via stations that should be displayed.",
 						"items": {
+                            "title": "viaStation",
 							"type":"string",
 							"minItems":0
 						}
 					},
 					"trainNumber":{
+                        "title": "trainNumber",
 						"type":"string",
 						"required":false,
 						"description":"The number of the train. This may contain alphanumeric symbols and dots."
@@ -495,9 +574,11 @@
 				}
 			},
 			"showText":{
+                "title": "showText",
 				"type":"object",
 				"properties":{
 					"text": {
+                        "title": "text",
 						"type":"string",
 						"required":false,
 						"description":"The text that should be displayed."
@@ -505,18 +586,22 @@
 				}
 			},
 			"clear":{
+                "title": "clear",
 				"type":"object",
 				"description":"The clear-command has no parameters."
 			},
 			"enqueueText":{
+                "title": "enqueueText",
 				"type":"object",
 				"properties":{
 					"text": {
+                        "title": "text",
 						"type":"string",
 						"required":true,
 						"description":"The Text that should be announced by the passenger information system."
 					},
 					"lang":{
+                        "title": "lang",
 						"type":"string",
 						"required":true,
 						"description":"The language the text is in. For example 'de' or 'en'"
@@ -524,13 +609,16 @@
 				}
 			},
 			"enqueueFiles":{
+                "title": "enqueueFiles",
 				"type":"object",
 				"properties":{
 					"playList": {
+                        "title": "playList",
 						"type":"array",
 						"required":true,
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
 						"items":{
+                            "title": "fileName",
 							"type":"string",
 							"description":"A filename that should be played. This has to match with the filePath of one file in the files array of the schedule."
 						}
@@ -538,37 +626,44 @@
 				}
 			},
 			"clearQueue":{
+                "title": "clearQueue",
 				"type":"object",
 				"description":"The clearQueue-command has no parameters."
 			},
 			"mute":{
+                "title": "mute",
 				"type":"object",
 				"description":"The mute-command has no parameters."
 			},
 			"unmute":{
+                "title": "unmute",
 				"type":"object",
 				"description":"The unmute-command has no parameters."
 			}
 		},
 		"routeStationIdentifier": {
+            "title": "routeStationIdentifier",
 			"type":"object",
 			"id": "#routeStationIdentifier",
 			"description": "Identifies a station uniquely on a route. Contains the idCode and the sequence number of the station in the route.",
 			"required":true,
 			"properties": {
 				"idCode": {
+                    "title": "idCode",
 					"type":"string",
 					"description": "The id code of the station, like APPZ for Appenzell.",
 					"id": "#idCode",
 					"required":true
 				},
 				"sequenceNumber": {
+                    "title": "sequenceNumber",
 					"type":"number",
 					"description": "The sequence number of the station on the route.",
 					"id": "#sequenceNumber",
 					"required":true
 				},
 				"externalIdentifier": {
+                    "title": "externalIdentifier",
 					"type": "string",
 					"description": "A unique identifier for the station, this could be any external identifier, for example the REC_ORT number of a VDV452 schedule Import.",
 					"id": "#externalIdentifier",
@@ -577,24 +672,28 @@
 			}
 		},
 		"multiTractionTrains": {
+            "title": "multiTractionTrains",
 			"type": "object",
 			"id": "#multiTractionTrains",
 			"description": "",
 			"required": false,
 			"properties": {
 				"number": {
+                    "title": "number",
 					"type":"string",
 					"description": "The number of the train. This may contain alphanumeric symbols and dots.",
 					"id": "#number",
 					"required":true
 				},
 				"piNumber": {
+                    "title": "piNumber",
 					"type":"string",
 					"description": "The pi number of the train. This may contain alphanumeric symbols and dots.",
 					"id": "#piNumber",
 					"required":true
 				},
 				"arrivalStationIdCode": {
+                    "title": "arrivalStationIdCode",
 					"type":"string",
 					"description": "The id code of the arrival station of this multitraction partner train.",
 					"id": "#arrivalStationIdCode",
@@ -603,23 +702,29 @@
 			}
 		},
 		"specialAnnouncementPossibleCommands": {
+            "title": "specialAnnouncementPossibleCommands",
 			"showText":{
+                "title": "showText",
 				"type":"object",
 				"description": "Can be used to display a predefined text on the configured output channels",
 				"properties":{
 					"name": {
+                        "title": "name",
 						"default": "showText"
 					},
 					"channels": {
+                        "title": "channels",
 						"type":"array",
 						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['display_interior.pis', 'display_exterior.front', 'display_exterior.side']",
 						"items": {
+                            "title": "channel",
 							"type":"string",
 							"minItems":1
 						}
 					},
 					"text": {
+                        "title": "text",
 						"type":"string",
 						"required":true,
 						"description":"The text that should be displayed. For a multi language text, the text can be defined in different languages with a '|' separator, for example: 'Willkommen|Welcome|Bienvenue'"
@@ -627,41 +732,50 @@
 				}
 			},
 			"showDestination":{
+                "title": "showDestination",
 				"type":"object",
 				"description": "Can be used to display the destination of the train on the displays.",
 				"properties":{
 					"name": {
+                        "title": "name",
 						"default": "showDestination"
 					},
 					"channels": {
+                        "title": "channels",
 						"type":"array",
 						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['display_exterior.side', 'display_exterior.front']",
 						"items": {
+                            "title": "channel",
 							"type":"string",
 							"minItems":1
 						}
 					},
 					"line": {
+                        "title": "line",
 						"type":"string",
 						"required":false,
 						"description":"The line that should be displayed. For example 'S21'."
 					},
 					"destination":{
+                        "title": "destination",
 						"type":"string",
 						"required":true,
 						"description":"The name of the destination station that should be displayed."
 					},
 					"via":{
+                        "title": "via",
 						"type":"array",
 						"required":false,
 						"description":"(optional) The via stations that should be displayed.",
 						"items": {
+                            "title": "viaStation",
 							"type":"string",
 							"minItems":0
 						}
 					},
 					"trainNumber":{
+                        "title": "trainNumber",
 						"type":"string",
 						"required":false,
 						"description":"The number of the train. This may contain alphanumeric symbols and dots."
@@ -669,28 +783,33 @@
 				}
 			},
 			"showNote":{
+                "title": "showNote",
 				"type":"object",
 				"description": "Can be used to display a predefined text with a predefined title on the TFT devices.",
 				"properties":{
 					"name": {
-						"default": "showNote",
+                        "title": "name",
 						"required":true
 					},
 					"type": {
+                        "title": "type",
 						"enum":["notice", "alert"],
 						"required":true,
 						"description": "When the type is notice, this will be cause usually displaying the announcement's title with a blue background, this is mainly used for operational informations. When the type is alert, the title's background will be red, this is mainly used for disruption informations."
 					},
 					"channels": {
+                        "title": "channels",
 						"type":"array",
 						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['display_interior.pis']",
 						"items": {
+                            "title": "channel",
 							"type":"string",
 							"minItems":1
 						}
 					},
 					"text": {
+                        "title": "text",
 						"type":"string",
 						"required":true,
 						"description":"The text that should be displayed."
@@ -698,56 +817,67 @@
 				}
 			},
 			"enqueueAlert":{
+                "title": "enqueueAlert",
 				"type":"object",
 				"description": "Can be used to simultaneously play a list audio files and to display the according information text on the TFTs ",
 				"properties":{
 					"name": {
-						"default": "enqueueAlert",
+                        "title": "name",
 						"required":true
 					},
 					"type": {
+                        "title": "type",
 						"enum":["notice", "alert"],
 						"required":true,
 						"description": "When the type is notice, this will be cause usually displaying the announcement's title with a blue background, this is mainly used for operational informations. When the type is alert, the title's background will be red, this is mainly used for disruption informations."
 					},
 					"autoCancel": {
+                        "title": "autoCancel",
 						"default": "immediate",
 						"required":true,
 						"description":"Indicates that this command should immediately be canceled to not be observed as an active schedule command override"
 					},
 					"channels": {
+                        "title": "channels",
 						"type":"array",
 						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['audio_interior.pis', 'audio_exterior.pis']",
 						"items": {
+                            "title": "channel",
 							"type":"string",
 							"minItems":1
 						}
 					},
 					"announcements": {
+                        "title": "announcements",
 						"type":"array",
 						"description":"A list of announcements that should be played in order. This can be a list of localized announcements.",
 						"required":true,
 						"items": [{
+                            "title": "announcement",
 							"type":"object",
 							"description": "The announcement object properties.",
 							"required":true,
 							"properties": {
 								"title": {
+                                    "title": "title",
 									"type": "string",
 									"required": true,
 									"description": "The title of the announcement that should be displayed on the displays."
 								},
 								"text": {
+                                    "title": "text",
 									"type": "string",
 									"required": true,
 									"description": "The visual text of the announcement that should be displayed on the displays."
 								},
 								"files": {
+                                    "title": "files",
 									"type":"array",
 									"required":true,
 									"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
 									"items":{
+                                        "title": "fileName",
 										"type":"string",
 										"description":"A filename that should be played. This has to match with the filePath of one file in the files array of the schedule."
 									}
@@ -758,26 +888,32 @@
 				}
 			},
 			"enqueueFiles":{
+                "title": "enqueueFiles",
 				"type":"object",
 				"description": "Can be used to play a list audio files.",
 				"properties":{
 					"name": {
+                        "title": "name",
 						"default": "enqueueFiles"
 					},
 					"channels": {
+                        "title": "channels",
 						"type":"array",
 						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['audio_interior.pis', 'audio_exterior.pis']",
 						"items": {
+                            "title": "channel",
 							"type":"string",
 							"minItems":1
 						}
 					},
 					"playList": {
+                        "title": "playList",
 						"type":"array",
 						"required":true,
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
 						"items":{
+                            "title": "fileName",
 							"type":"string",
 							"description":"A filename that should be played. This has to match with the filePath of one file in the files array of the schedule."
 						}

--- a/djsf.json
+++ b/djsf.json
@@ -57,7 +57,6 @@
             "title": "files",
 			"type": "array",
 			"description": "Contains a list of all files in the schedule and those essential for special announcements.",
-			"minItems": 0,
 			"id": "http://diloc.de/djsf/files",
 			"items": {
                 "title": "file",
@@ -142,7 +141,7 @@
 								{
                                     "title": "routeStation",
 									"type":"object",
-									"required":["stopType"],
+									"required":["routeStationIdentifier","stopType"],
 									"id": "http://diloc.de/djsf/train/routeStations",
 									"properties":{
 										"connections": {
@@ -341,7 +340,6 @@
 							"type":"array",
 							"description": "This could be null, an empty array or an array of objects. Null means that this trains does not have any multitraction partner. An empty array means that this trains is a multitraction partner for another leading train. And an array of objects means that this train has multitraction partner and it's the leading train. The order of the trains in the array defines the order of trains in the multitraction.",
 							"id": "#multiTractionTrains",
-							"minItems": 0,
 							"items":{
 								"$ref":"#/definitions/multiTractionTrains"
 							}
@@ -353,7 +351,6 @@
             "title": "specialAnnouncements",
 			"type":"array",
 			"description": "Contains a list of special announcements",
-			"minItems": 0,
 			"id": "http://diloc.de/djsf/specialAnnouncements",
 			"items": {
                 "title": "specialAnnouncement",
@@ -494,7 +491,6 @@
                         "title": "via",
 						"type":"array",
 						"description":"The via stations that should be displayed.",
-                        "minItems": 0,
 						"items": {
                             "title": "viaStation",
 							"type": "string"
@@ -690,7 +686,6 @@
                         "title": "via",
 						"type":"array",
 						"description":"(optional) The via stations that should be displayed.",
-                        "minItems": 0,
 						"items": {
                             "title": "viaStation",
 							"type":"string"
@@ -825,7 +820,8 @@
                         "title": "playList",
 						"type":"array",
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
-						"items":{
+						"minItems":1,
+                        "items":{
                             "title": "fileName",
 							"type":"string",
 							"description":"A filename that should be played. This has to match with the filePath of one file in the files array of the schedule."

--- a/djsf.json
+++ b/djsf.json
@@ -369,7 +369,6 @@
 			"id": "http://diloc.de/djsf/specialAnnouncements",
 			"items": {
                 "title": "specialAnnouncement",
-				"minItems":0,
 				"type":"object",
 				"description": "The specialAnnouncement encapsulates details and data of a special announcement",
 				"id": "http://diloc.de/djsf/specialAnnouncement",

--- a/djsf.json
+++ b/djsf.json
@@ -501,10 +501,10 @@
                         "title": "via",
 						"type":"array",
 						"description":"The via stations that should be displayed.",
+                        "minItems": 0,
 						"items": {
                             "title": "viaStation",
-							"type":"string",
-							"minItems":0
+							"type": "string"
 						}
 					},
 					"trainNumber":{
@@ -650,10 +650,10 @@
                         "title": "channels",
 						"type":"array",
 						"description":"The output channels on which this command will be executed. For example: ['display_interior.pis', 'display_exterior.front', 'display_exterior.side']",
+                        "minItems": 1,
 						"items": {
                             "title": "channel",
-							"type":"string",
-							"minItems":1
+							"type": "string"
 						}
 					},
 					"text": {
@@ -677,10 +677,10 @@
                         "title": "channels",
 						"type":"array",
 						"description":"The output channels on which this command will be executed. For example: ['display_exterior.side', 'display_exterior.front']",
+                        "minItems": 1,
 						"items": {
                             "title": "channel",
-							"type":"string",
-							"minItems":1
+							"type":"string"
 						}
 					},
 					"line": {
@@ -697,10 +697,10 @@
                         "title": "via",
 						"type":"array",
 						"description":"(optional) The via stations that should be displayed.",
+                        "minItems": 0,
 						"items": {
                             "title": "viaStation",
-							"type":"string",
-							"minItems":0
+							"type":"string"
 						}
 					},
 					"trainNumber":{
@@ -729,10 +729,10 @@
                         "title": "channels",
 						"type":"array",
 						"description":"The output channels on which this command will be executed. For example: ['display_interior.pis']",
+                        "minItems": 1,
 						"items": {
                             "title": "channel",
-							"type":"string",
-							"minItems":1
+							"type":"string"
 						}
 					},
 					"text": {
@@ -766,10 +766,10 @@
                         "title": "channels",
 						"type":"array",
 						"description":"The output channels on which this command will be executed. For example: ['audio_interior.pis', 'audio_exterior.pis']",
+                        "minItems": 1,
 						"items": {
                             "title": "channel",
-							"type":"string",
-							"minItems":1
+							"type":"string"
 						}
 					},
 					"announcements": {
@@ -822,10 +822,10 @@
                         "title": "channels",
 						"type":"array",
 						"description":"The output channels on which this command will be executed. For example: ['audio_interior.pis', 'audio_exterior.pis']",
+                        "minItems": 1,
 						"items": {
                             "title": "channel",
-							"type":"string",
-							"minItems":1
+							"type": "string"
 						}
 					},
 					"playList": {

--- a/djsf.json
+++ b/djsf.json
@@ -1,61 +1,54 @@
 {
-	"type":"object",
+    "type":"object",
     "$schema": "https://json-schema.org/draft-04/schema#",
-	"id": "http://diloc.de/djsf",
+    "id": "http://diloc.de/djsf",
     "title":"DiLoc JSON Schedule Format",
-	"description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.5.2",
-	"required":false,
+    "description":"This schema describes the DiLoc JSON Schedule Format. Version of the Schema: 2.5.2",
+    "required":["meta","files","trains","specialAnnouncements"],
 	"properties":{
 		"meta":{
             "title":"meta",
 			"type":"object",
-			"required":true,
+			"required":["validFrom","validTo","version","djsfSchemaVersion","type","createdAt"],
 			"description":"Contains meta-information about the schedule.",
 			"properties":{
 				"validFrom":{
                     "title":"validFrom",
 					"type":"string",
 					"format":"date-time",
-					"required":true,
 					"description":"The date-time from when the schedule is valid."
 				},
 				"validTo":{
                     "title":"validTo",
 					"type":"string",
 					"format":"date-time",
-					"required":true,
 					"description":"The date-time until this schedule is valid."
 				},
 				"version":{
                     "title":"version",
 					"type":"string",
-					"required":true,
 					"description":"The version describes the version of the schedule. The version usually starts with 1.0 and is increased for newer versions 1.1, 1.2, etc)"
 				},
 				"djsfSchemaVersion":{
                     "title":"djsfSchemaVersion",
 					"type":"string",
-					"required":true,
 					"description":"The version describes the djsf schema version of the generated schedule."
 				},
 				"type": {
                     "title":"type",
 					"enum":["period","day"],
 					"description": "The type of the generated schedule (\"period\" or \"day\").",
-					"id": "#scheduletype",
-					"required":true
+					"id": "#scheduletype"
 				},
 				"createdAt": {
                     "title":"createdAt",
 					"type":"string",
 					"format":"date-time",
-					"required":true,
 					"description": "The timestamp when the schedule is created in ISO-8601 format. For example: 2022-12-02T10:20:39+00:00"
 				},
 				"fileDownloadUrl": {
                     "title":"fileDownloadUrl",
 					"type":"string",
-					"required":false,
 					"description": "The URL with path to the API endpoint to download schedule audio files. The file path and mpi device id code are added as query parameter. Example: https://api.example.com/schedules/audio/download?filePath=abc/a.mp3&mpiDeviceIdCode=test"
 				}
 			}
@@ -66,30 +59,26 @@
 			"description": "Contains a list of all files in the schedule and those essential for special announcements.",
 			"minItems": 0,
 			"id": "http://diloc.de/djsf/files",
-			"required":true,
 			"items": {
                 "title": "file",
 				"type":"object",
 				"description": "The file object contains all information about the file to find it in the schedule-file or download it from the DiLoc-Server.",
 				"id": "http://diloc.de/djsf/file",
-				"required":false,
+                "required":["filePath","type","md5Checksum"],
 				"properties": {
 					"filePath": {
                         "title": "filePath",
 						"type": "string",
-						"required": true,
 						"description": "The path to the file (including filename) relative to the files folder in the schedule file. This path is used in the playList of the enqueueFiles command."
 					},
 					"type": {
                         "title": "type",
 						"enum":["audio","image","video"],
-						"description": "The type of the file.",
-						"required":true
+						"description": "The type of the file."
 					},
 					"md5Checksum": {
                         "title": "md5Checksum",
 						"type": "string",
-						"required": true,
 						"description": "The md5 checksum of the file."
 					}
 				}
@@ -101,49 +90,44 @@
 			"description": "Contains a list of all trains in the schedule.",
 			"minItems": 1,
 			"id": "http://diloc.de/djsf/trains",
-			"required":true,
 			"items":
 				{
                     "title":"train",
 					"type":"object",
 					"description": "The train object contains all information about a train.",
 					"id": "http://diloc.de/djsf/train",
-					"required":false,
+					"required":["departureTime","routeStations"],
 					"properties":{
 						"trainNumber": {
                             "title": "trainNumber",
 							"type":"string",
 							"description": "The number of the train. This may contain alphanumeric symbols and dots.",
-							"id": "http://diloc.de/djsf/trains/0/trainNumber",
-							"required":false
+							"id": "http://diloc.de/djsf/trains/0/trainNumber"
 						},
 						"piNumber": {
                             "title": "piNumber",
 							"type":"string",
 							"description": "The pi number of the train. This may contain alphanumeric symbols and dots.",
-							"id": "http://diloc.de/djsf/trains/0/piNumber",
-							"required":false
+							"id": "http://diloc.de/djsf/trains/0/piNumber"
 						},
 						"departureTime": {
                             "title": "departureTime",
 							"type":"string",
 							"description": "The departure time of the train in H:i:s format.",
-							"id": "#departureTime",
-							"required":true
+							"id": "#departureTime"
 						},
 						"product": {
                             "title": "product",
 							"type":"object",
 							"description": "The product information about a train.",
 							"id": "#product",
-							"required":false,
+							"required":["name"],
 							"properties":{
 								"name": {
                                     "title": "name",
 									"type":"string",
 									"description": "The product name.",
-									"id": "#name",
-									"required":true
+									"id": "#name"
 								}
 							}
 						},
@@ -154,12 +138,11 @@
 							"description": "Contains all stations the train will travel.",
 							"minItems": 2,
 							"id": "http://diloc.de/djsf/train/routeStations",
-							"required":true,
 							"items":
 								{
                                     "title": "routeStation",
 									"type":"object",
-									"required":true,
+									"required":["stopType"],
 									"id": "http://diloc.de/djsf/train/routeStations",
 									"properties":{
 										"connections": {
@@ -167,64 +150,56 @@
 											"type":"array",
 											"description": "An array of connections that should be displayed at this station.",
 											"id": "#connections",
-											"required":false,
 											"items":
 												{
                                                     "title": "connection",
 													"type":"object",
 													"description": "Contains information about a connection at the station.",
 													"id": "#connection",
-													"required":false,
+													"required":["category","departureTime","destination"],
 													"properties":{
 														"category": {
                                                             "title": "category",
 															"type":"string",
 															"enum":["underground","citytrain","tram","bus","localtraffic","longdistancetraffic"],
 															"description": "This gives information about how the train should be displayed.",
-															"id": "#category",
-															"required":true
+															"id": "#category"
 														},
 														"departureTime": {
                                                             "title": "departureTime",
 															"type":"string",
 															"description": "The time when the connected train/bus etc. departs",
-															"id": "#departureTime",
-															"required":true
+															"id": "#departureTime"
 														},
 														"destination": {
                                                             "title": "destination",
 															"type":"string",
 															"description": "The destination the connected product travels to.",
-															"id": "#destination",
-															"required":true
+															"id": "#destination"
 														},
 														"line": {
                                                             "title": "line",
 															"type":"string",
 															"description": "The line of the connected product. For example: 201",
-															"id": "#line",
-															"required":false
+															"id": "#line"
 														},
 														"note": {
                                                             "title": "note",
 															"type":"string",
 															"description": "A note containing additional information about the connection.",
-															"id": "#note",
-															"required":false
+															"id": "#note"
 														},
 														"platform": {
                                                             "title": "platform",
 															"type":"string",
 															"description": "The platform at which the connected product departs.Examples for this are 1, A or 3A. ",
-															"id": "#platform",
-															"required":false
+															"id": "#platform"
 														},
 														"product": {
                                                             "title": "product",
 															"type":"string",
 															"description": "The name of the product like 'S12' or 'IC', 'IR', etc. Depending on the content it may be necessary to display a pictogram of the given product. For example for the product IC, IR there are special pictograms in Switzerland that should be displayed in this case.",
-															"id": "#product",
-															"required":false
+															"id": "#product"
 														}
 													}
 												}
@@ -239,22 +214,19 @@
                                             "title": "stopType",
 											"enum":["departure","conditionalHalt","passthrough","technical","exitOnly","arrival", "halt"],
 											"description": "The type of the stop.",
-											"id": "#stopType",
-											"required":true
+											"id": "#stopType"
 										},
 										"timeTableArrivalTime": {
                                             "title": "timeTableArrivalTime",
 											"type":"number",
 											"description": "The time table arrival time in seconds after the departure of the train. The order of the routeStations must be ascending over timeTableArrivalTime.",
-											"id": "#timeTableArrivalTime",
-											"required":false
+											"id": "#timeTableArrivalTime"
 										},
 										"timeTableDepartureTime": {
                                             "title": "timeTableDepartureTime",
 											"type":"number",
 											"description": "The time table departure time in seconds after the departure of the train. If stopType equals 'passthrough' the timeTableDepartureTime must be the same like timeTableArrivalTime.",
-											"id": "#timeTableDepartureTime",
-											"required":false
+											"id": "#timeTableDepartureTime"
 										}
 									}
 								}
@@ -266,41 +238,37 @@
 							"type":"object",
 							"description": "The script contains all necessary information to drive the passenger information for this train.",
 							"id": "http://diloc.de/djsf/train/script",
-							"required":false,
+							"required":["tracks"],
 							"properties":{
 								"tracks": {
                                     "title": "tracks",
 									"type":"array",
 									"description": "A track contains the information what a specific output device in the train should do.",
 									"id": "http://diloc.de/djsf/train/script/tracks",
-									"required":true,
 									"items":[
 										{
                                             "title": "track",
 											"type":"object",
 											"id": "http://diloc.de/djsf/trains/script/track",
-											"required":false,
+											"required":["identifier", "startCommands"],
 											"properties":{
 												"type": {
                                                     "title": "type",
 													"enum":["led","tft","audio","display_interior","display_exterior"],
 													"description":"The type of track.",
-													"id": "#type",
-													"required":false
+													"id": "#type"
 												},
 												"identifier": {
                                                     "title": "identifier",
 													"type":"string",
 													"description": "The identifier that identifies the channel. This is unique per script.",
-													"id": "#identifier",
-													"required":true
+													"id": "#identifier"
 												},
 												"startCommands": {
                                                     "title": "startCommands",
 													"type":"array",
 													"description": "Contains commands that should be sent to the output when the train is activated by the driver.",
 													"id": "#startCommands",
-													"required":true,
 													"items":[{
                                                         "title": "startCommand",
 														"type":"object",
@@ -311,19 +279,16 @@
                                                     "title": "stations",
 													"type":"array",
 													"id": "#stations",
-													"required":false,
 													"items":[
 														{
                                                             "title": "station",
 															"type":"object",
 															"id": "#station",
-															"required":false,
 															"properties":{
 																"commands": {
                                                                     "title": "commands",
 																	"type":"array",
 																	"id": "#commands",
-																	"required":false,
 																	"items":
 																	{
                                                                         "title": "command",
@@ -350,42 +315,35 @@
 							"type":"array",
 							"description": "This defines on which days the train travels. This only applies for period schedules. On day schedules only the trains that really travel on the day are included in the schedule.",
 							"id": "#travelsOnDays",
-							"required":false,
 							"items":
 								{
                                     "title": "day",
 									"enum":["mo","th","tu","we","fr","sa","su"],
-									"description": "The days the train travels. ",
-									"required":false
+									"description": "The days the train travels. "
 								}
-
 
 						},
 						"nextNumber": {
                             "title": "nextNumber",
 							"type":"string",
 							"description": "The number of the next train in case the train returns as another train number. This can be used to directly select the next train when the train arrives at its destination station. This can also be used to define a continuation, when another train number continue the trip.",
-							"id": "#nextNumber",
-							"required":false
+							"id": "#nextNumber"
 						},
                         "nextPiNumber": {
                             "title": "nextPiNumber",
-                          "type":"string",
-                          "description": "The pi number of the next train.",
-                          "id": "#nextPiNumber",
-                          "required":false
+                            "type":"string",
+                            "description": "The pi number of the next train.",
+                            "id": "#nextPiNumber"
                         },
 						"nextLinkType": {
                             "title": "nextLinkType",
 							"type":"array",
 							"description": "Defines the link type of two train numbers.",
 							"id": "#nextLinkType",
-							"required":false,
 							"items": {
                                 "title": "linkType",
 								"enum":["circular", "continuation"],
-								"description": "Circular defines the link type for regular circulation trips. Continuation defines a link type for a train which does not circulate at the destination station.",
-								"required":false
+								"description": "Circular defines the link type for regular circulation trips. Continuation defines a link type for a train which does not circulate at the destination station."
 							}
 						},
 						"multiTractionTrains" : {
@@ -393,7 +351,6 @@
 							"type":"array",
 							"description": "This could be null, an empty array or an array of objects. Null means that this trains does not have any multitraction partner. An empty array means that this trains is a multitraction partner for another leading train. And an array of objects means that this train has multitraction partner and it's the leading train. The order of the trains in the array defines the order of trains in the multitraction.",
 							"id": "#multiTractionTrains",
-							"required":false,
 							"minItems": 0,
 							"items":[{
                                 "title": "multiTractionTrain",
@@ -410,43 +367,37 @@
 			"description": "Contains a list of special announcements",
 			"minItems": 0,
 			"id": "http://diloc.de/djsf/specialAnnouncements",
-			"required":true,
 			"items": {
                 "title": "specialAnnouncement",
 				"minItems":0,
 				"type":"object",
 				"description": "The specialAnnouncement encapsulates details and data of a special announcement",
 				"id": "http://diloc.de/djsf/specialAnnouncement",
-				"required":false,
+				"required":["name", "description", "number", "commands"],
 				"properties": {
 					"name": {
                         "title": "name",
 						"type": "string",
-						"required": true,
 						"description": "The short name of the specialAnnouncement."
 					},
 					"description": {
                         "title": "description",
 						"type": "string",
-						"required": true,
 						"description": "The description of the specialAnnouncement."
 					},
 					"number": {
                         "title": "number",
 						"type": "integer",
-						"required": true,
 						"description": "The number of the specialAnnouncement used mainly to easily find/identify a specialAnnouncement by the driver. This musst be a unique number."
 					},
 					"sortOrder": {
                         "title": "sortOrder",
 						"type": "integer",
-						"required": false,
 						"description": "An optional property that can be used by DiLoc|OnBoard to defines the order in which special announcements are arranged"
 					},
 					"commands": {
                         "title": "commands",
 						"type": "array",
-						"required": true,
 						"description": "An array of commands that the specialAnnouncement will execute when it is activated",
 						"items":[{
                             "title": "command",
@@ -465,29 +416,27 @@
 			}
 		}
 	},
-	"definitions":{
+    "definitions":{
 		"command":{
             "title": "command",
+			"required":["name", "on"],
 			"properties":{
 				"name": {
                     "title": "name",
 					"type":"string",
 					"description": "The name of the command that should be sent.",
-					"id": "http://diloc.de/djsf/trains/0/script/tracks/0/startCommands/0/name",
-					"required":true
+					"id": "http://diloc.de/djsf/trains/0/script/tracks/0/startCommands/0/name"
 				},
 				"on": {
                     "title": "on",
 					"type":["integer", "string"],
 					"description": "Describes where the action should be executed. This can either be a negative number like -100 or one of the fixed strings 'halt' and 'start'. Number are interpreted as meters before/after the station. 'halt' means when the train halts at the given station. 'start' means when the train starts and should be used inside startCommands. For pre announcements, this should contain 'plannedDepartureTime'",
-					"id": "http://diloc.de/djsf/trains/0/script/tracks/0/startCommands/0/name",
-					"required":true
+					"id": "http://diloc.de/djsf/trains/0/script/tracks/0/startCommands/0/name"
 				},
 				"timeOffset": {
                     "title": "timeOffset",
 					"type": ["integer"],
-					"description": "This is required, if parameter 'on' is 'planneddeparturetime'. This should contain for example '-100' to trigger an announcement hundred seconds before planned departure time.",
-					"required": false
+					"description": "This is required, if parameter 'on' is 'planneddeparturetime'. This should contain for example '-100' to trigger an announcement hundred seconds before planned departure time."
 				},
 				"params": {
                     "title": "params",
@@ -541,23 +490,21 @@
 			"showDestination":{
                 "title": "showDestination",
 				"type":"object",
+                "required": ["destination"],
 				"properties":{
 					"line": {
                         "title": "line",
 						"type":"string",
-						"required":false,
 						"description":"The line that should be displayed. For example 'S21'."
 					},
 					"destination":{
                         "title": "destination",
 						"type":"string",
-						"required":true,
 						"description":"The name of the destination station that should be displayed."
 					},
 					"via":{
                         "title": "via",
 						"type":"array",
-						"required":false,
 						"description":"The via stations that should be displayed.",
 						"items": {
                             "title": "viaStation",
@@ -568,7 +515,6 @@
 					"trainNumber":{
                         "title": "trainNumber",
 						"type":"string",
-						"required":false,
 						"description":"The number of the train. This may contain alphanumeric symbols and dots."
 					}
 				}
@@ -580,7 +526,6 @@
 					"text": {
                         "title": "text",
 						"type":"string",
-						"required":false,
 						"description":"The text that should be displayed."
 					}
 				}
@@ -593,17 +538,16 @@
 			"enqueueText":{
                 "title": "enqueueText",
 				"type":"object",
+                "required": ["text", "lang"],
 				"properties":{
 					"text": {
                         "title": "text",
 						"type":"string",
-						"required":true,
 						"description":"The Text that should be announced by the passenger information system."
 					},
 					"lang":{
                         "title": "lang",
 						"type":"string",
-						"required":true,
 						"description":"The language the text is in. For example 'de' or 'en'"
 					}
 				}
@@ -611,11 +555,11 @@
 			"enqueueFiles":{
                 "title": "enqueueFiles",
 				"type":"object",
+                "required": ["playList"],
 				"properties":{
 					"playList": {
                         "title": "playList",
 						"type":"array",
-						"required":true,
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
 						"items":{
                             "title": "fileName",
@@ -646,28 +590,25 @@
 			"type":"object",
 			"id": "#routeStationIdentifier",
 			"description": "Identifies a station uniquely on a route. Contains the idCode and the sequence number of the station in the route.",
-			"required":true,
+			"required":["idCode","sequenceNumber"],
 			"properties": {
 				"idCode": {
                     "title": "idCode",
 					"type":"string",
 					"description": "The id code of the station, like APPZ for Appenzell.",
-					"id": "#idCode",
-					"required":true
+					"id": "#idCode"
 				},
 				"sequenceNumber": {
                     "title": "sequenceNumber",
 					"type":"number",
 					"description": "The sequence number of the station on the route.",
-					"id": "#sequenceNumber",
-					"required":true
+					"id": "#sequenceNumber"
 				},
 				"externalIdentifier": {
                     "title": "externalIdentifier",
 					"type": "string",
 					"description": "A unique identifier for the station, this could be any external identifier, for example the REC_ORT number of a VDV452 schedule Import.",
-					"id": "#externalIdentifier",
-					"required": false
+					"id": "#externalIdentifier"
 				}
 			}
 		},
@@ -676,28 +617,25 @@
 			"type": "object",
 			"id": "#multiTractionTrains",
 			"description": "",
-			"required": false,
+			"required": ["number","piNumber","arrivalStationIdCode"],
 			"properties": {
 				"number": {
                     "title": "number",
 					"type":"string",
 					"description": "The number of the train. This may contain alphanumeric symbols and dots.",
-					"id": "#number",
-					"required":true
+					"id": "#number"
 				},
 				"piNumber": {
                     "title": "piNumber",
 					"type":"string",
 					"description": "The pi number of the train. This may contain alphanumeric symbols and dots.",
-					"id": "#piNumber",
-					"required":true
+					"id": "#piNumber"
 				},
 				"arrivalStationIdCode": {
                     "title": "arrivalStationIdCode",
 					"type":"string",
 					"description": "The id code of the arrival station of this multitraction partner train.",
-					"id": "#arrivalStationIdCode",
-					"required":true
+					"id": "#arrivalStationIdCode"
 				}
 			}
 		},
@@ -707,6 +645,7 @@
                 "title": "showText",
 				"type":"object",
 				"description": "Can be used to display a predefined text on the configured output channels",
+                "required": ["channels","text"],
 				"properties":{
 					"name": {
                         "title": "name",
@@ -715,7 +654,6 @@
 					"channels": {
                         "title": "channels",
 						"type":"array",
-						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['display_interior.pis', 'display_exterior.front', 'display_exterior.side']",
 						"items": {
                             "title": "channel",
@@ -726,7 +664,6 @@
 					"text": {
                         "title": "text",
 						"type":"string",
-						"required":true,
 						"description":"The text that should be displayed. For a multi language text, the text can be defined in different languages with a '|' separator, for example: 'Willkommen|Welcome|Bienvenue'"
 					}
 				}
@@ -735,6 +672,7 @@
                 "title": "showDestination",
 				"type":"object",
 				"description": "Can be used to display the destination of the train on the displays.",
+                "required": ["channels", "destination"],
 				"properties":{
 					"name": {
                         "title": "name",
@@ -743,7 +681,6 @@
 					"channels": {
                         "title": "channels",
 						"type":"array",
-						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['display_exterior.side', 'display_exterior.front']",
 						"items": {
                             "title": "channel",
@@ -754,19 +691,16 @@
 					"line": {
                         "title": "line",
 						"type":"string",
-						"required":false,
 						"description":"The line that should be displayed. For example 'S21'."
 					},
 					"destination":{
                         "title": "destination",
 						"type":"string",
-						"required":true,
 						"description":"The name of the destination station that should be displayed."
 					},
 					"via":{
                         "title": "via",
 						"type":"array",
-						"required":false,
 						"description":"(optional) The via stations that should be displayed.",
 						"items": {
                             "title": "viaStation",
@@ -777,7 +711,6 @@
 					"trainNumber":{
                         "title": "trainNumber",
 						"type":"string",
-						"required":false,
 						"description":"The number of the train. This may contain alphanumeric symbols and dots."
 					}
 				}
@@ -786,21 +719,20 @@
                 "title": "showNote",
 				"type":"object",
 				"description": "Can be used to display a predefined text with a predefined title on the TFT devices.",
+                "required": ["name", "type", "channels", "text"],
 				"properties":{
 					"name": {
                         "title": "name",
-						"required":true
+						"default": "showNote"
 					},
 					"type": {
                         "title": "type",
 						"enum":["notice", "alert"],
-						"required":true,
 						"description": "When the type is notice, this will be cause usually displaying the announcement's title with a blue background, this is mainly used for operational informations. When the type is alert, the title's background will be red, this is mainly used for disruption informations."
 					},
 					"channels": {
                         "title": "channels",
 						"type":"array",
-						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['display_interior.pis']",
 						"items": {
                             "title": "channel",
@@ -811,7 +743,6 @@
 					"text": {
                         "title": "text",
 						"type":"string",
-						"required":true,
 						"description":"The text that should be displayed."
 					}
 				}
@@ -820,27 +751,25 @@
                 "title": "enqueueAlert",
 				"type":"object",
 				"description": "Can be used to simultaneously play a list audio files and to display the according information text on the TFTs ",
-				"properties":{
+				"required": ["name", "type", "autoCancel", "channels","announcements"],
+                "properties":{
 					"name": {
                         "title": "name",
-						"required":true
+						"default": "enqueueAlert"
 					},
 					"type": {
                         "title": "type",
 						"enum":["notice", "alert"],
-						"required":true,
 						"description": "When the type is notice, this will be cause usually displaying the announcement's title with a blue background, this is mainly used for operational informations. When the type is alert, the title's background will be red, this is mainly used for disruption informations."
 					},
 					"autoCancel": {
                         "title": "autoCancel",
 						"default": "immediate",
-						"required":true,
 						"description":"Indicates that this command should immediately be canceled to not be observed as an active schedule command override"
 					},
 					"channels": {
                         "title": "channels",
 						"type":"array",
-						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['audio_interior.pis', 'audio_exterior.pis']",
 						"items": {
                             "title": "channel",
@@ -852,29 +781,26 @@
                         "title": "announcements",
 						"type":"array",
 						"description":"A list of announcements that should be played in order. This can be a list of localized announcements.",
-						"required":true,
+                        "minItems":1,
 						"items": [{
                             "title": "announcement",
 							"type":"object",
 							"description": "The announcement object properties.",
-							"required":true,
+							"required":["title", "text", "files"],
 							"properties": {
 								"title": {
                                     "title": "title",
 									"type": "string",
-									"required": true,
 									"description": "The title of the announcement that should be displayed on the displays."
 								},
 								"text": {
                                     "title": "text",
 									"type": "string",
-									"required": true,
 									"description": "The visual text of the announcement that should be displayed on the displays."
 								},
 								"files": {
                                     "title": "files",
 									"type":"array",
-									"required":true,
 									"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
 									"items":{
                                         "title": "fileName",
@@ -891,6 +817,7 @@
                 "title": "enqueueFiles",
 				"type":"object",
 				"description": "Can be used to play a list audio files.",
+                "required": ["channels","playList"],
 				"properties":{
 					"name": {
                         "title": "name",
@@ -899,7 +826,6 @@
 					"channels": {
                         "title": "channels",
 						"type":"array",
-						"required":true,
 						"description":"The output channels on which this command will be executed. For example: ['audio_interior.pis', 'audio_exterior.pis']",
 						"items": {
                             "title": "channel",
@@ -910,7 +836,6 @@
 					"playList": {
                         "title": "playList",
 						"type":"array",
-						"required":true,
 						"description":"A list of files that should be played in order. These files may only be text-fragments that form a complete sentence when played one after another.",
 						"items":{
                             "title": "fileName",

--- a/djsf.json
+++ b/djsf.json
@@ -245,68 +245,64 @@
 									"type":"array",
 									"description": "A track contains the information what a specific output device in the train should do.",
 									"id": "http://diloc.de/djsf/train/script/tracks",
-									"items":[
-										{
-                                            "title": "track",
-											"type":"object",
-											"id": "http://diloc.de/djsf/trains/script/track",
-											"required":["identifier", "startCommands"],
-											"properties":{
-												"type": {
-                                                    "title": "type",
-													"enum":["led","tft","audio","display_interior","display_exterior"],
-													"description":"The type of track.",
-													"id": "#type"
-												},
-												"identifier": {
-                                                    "title": "identifier",
-													"type":"string",
-													"description": "The identifier that identifies the channel. This is unique per script.",
-													"id": "#identifier"
-												},
-												"startCommands": {
-                                                    "title": "startCommands",
-													"type":"array",
-													"description": "Contains commands that should be sent to the output when the train is activated by the driver.",
-													"id": "#startCommands",
-													"items":[{
-                                                        "title": "startCommand",
-														"type":"object",
-														"$ref":"#/definitions/command"
-													}]
-												},
-												"stations": {
-                                                    "title": "stations",
-													"type":"array",
-													"id": "#stations",
-													"items":[
-														{
-                                                            "title": "station",
-															"type":"object",
-															"id": "#station",
-															"properties":{
-																"commands": {
-                                                                    "title": "commands",
-																	"type":"array",
-																	"id": "#commands",
-																	"items":
-																	{
-                                                                        "title": "command",
-																		"type":"object",
-																		"$ref":"#/definitions/command"
-																	}
-																},
-																"routeStationIdentifier": {
-                                                                    "title": "routeStationIdentifier",
-																	"$ref":"#/definitions/routeStationIdentifier"
-																}
-															}
-														}
-													]
-												}
-											}
-										}
-									]
+									"items": {
+                                        "title": "track",
+                                        "type":"object",
+                                        "id": "http://diloc.de/djsf/trains/script/track",
+                                        "required":["identifier", "startCommands"],
+                                        "properties":{
+                                            "type": {
+                                                "title": "type",
+                                                "enum":["led","tft","audio","display_interior","display_exterior"],
+                                                "description":"The type of track.",
+                                                "id": "#type"
+                                            },
+                                            "identifier": {
+                                                "title": "identifier",
+                                                "type":"string",
+                                                "description": "The identifier that identifies the channel. This is unique per script.",
+                                                "id": "#identifier"
+                                            },
+                                            "startCommands": {
+                                                "title": "startCommands",
+                                                "type":"array",
+                                                "description": "Contains commands that should be sent to the output when the train is activated by the driver.",
+                                                "id": "#startCommands",
+                                                "items":{
+                                                    "title": "startCommand",
+                                                    "type":"object",
+                                                    "$ref":"#/definitions/command"
+                                                }
+                                            },
+                                            "stations": {
+                                                "title": "stations",
+                                                "type":"array",
+                                                "id": "#stations",
+                                                "items": {
+                                                    "title": "station",
+                                                    "type":"object",
+                                                    "id": "#station",
+                                                    "properties":{
+                                                        "commands": {
+                                                            "title": "commands",
+                                                            "type":"array",
+                                                            "id": "#commands",
+                                                            "items":
+                                                            {
+                                                                "title": "command",
+                                                                "type":"object",
+                                                                "$ref":"#/definitions/command"
+                                                            }
+                                                        },
+                                                        "routeStationIdentifier": {
+                                                            "title": "routeStationIdentifier",
+                                                            "$ref":"#/definitions/routeStationIdentifier"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
 								}
 							}
 						},
@@ -352,11 +348,11 @@
 							"description": "This could be null, an empty array or an array of objects. Null means that this trains does not have any multitraction partner. An empty array means that this trains is a multitraction partner for another leading train. And an array of objects means that this train has multitraction partner and it's the leading train. The order of the trains in the array defines the order of trains in the multitraction.",
 							"id": "#multiTractionTrains",
 							"minItems": 0,
-							"items":[{
+							"items":{
                                 "title": "multiTractionTrain",
 								"type":"object",
 								"$ref":"#/definitions/multiTractionTrains"
-							}]
+							}
 						}
 					}
 				}
@@ -398,7 +394,7 @@
                         "title": "commands",
 						"type": "array",
 						"description": "An array of commands that the specialAnnouncement will execute when it is activated",
-						"items":[{
+						"items":{
                             "title": "command",
 							"type":"object",
 							"description": "The parameters for the command. Parameters are command specific. So each command-type has different parameters.",
@@ -409,7 +405,7 @@
 								{ "$ref":"#/definitions/specialAnnouncementPossibleCommands/enqueueAlert" },
 								{ "$ref":"#/definitions/specialAnnouncementPossibleCommands/showNote" }
 							]
-						}]
+						}
 					}
 				}
 			}
@@ -781,7 +777,7 @@
 						"type":"array",
 						"description":"A list of announcements that should be played in order. This can be a list of localized announcements.",
                         "minItems":1,
-						"items": [{
+						"items": {
                             "title": "announcement",
 							"type":"object",
 							"description": "The announcement object properties.",
@@ -808,7 +804,7 @@
 									}
 								}
 							}
-						}]
+						}
 					}
 				}
 			},

--- a/djsf.json
+++ b/djsf.json
@@ -637,7 +637,7 @@
 				"properties":{
 					"name": {
                         "title": "name",
-						"default": "showText"
+						"enum": "showText"
 					},
 					"channels": {
                         "title": "channels",
@@ -664,7 +664,7 @@
 				"properties":{
 					"name": {
                         "title": "name",
-						"default": "showDestination"
+						"enum": "showDestination"
 					},
 					"channels": {
                         "title": "channels",
@@ -711,7 +711,7 @@
 				"properties":{
 					"name": {
                         "title": "name",
-						"default": "showNote"
+						"enum": "showNote"
 					},
 					"type": {
                         "title": "type",
@@ -743,7 +743,7 @@
                 "properties":{
 					"name": {
                         "title": "name",
-						"default": "enqueueAlert"
+						"enum": "enqueueAlert"
 					},
 					"type": {
                         "title": "type",
@@ -809,7 +809,7 @@
 				"properties":{
 					"name": {
                         "title": "name",
-						"default": "enqueueFiles"
+						"enum": "enqueueFiles"
 					},
 					"channels": {
                         "title": "channels",

--- a/djsf.json
+++ b/djsf.json
@@ -430,7 +430,7 @@
 				},
 				"timeOffset": {
                     "title": "timeOffset",
-					"type": ["integer"],
+					"type": "integer",
 					"description": "This is required, if parameter 'on' is 'planneddeparturetime'. This should contain for example '-100' to trigger an announcement hundred seconds before planned departure time."
 				},
 				"params": {

--- a/djsf.json
+++ b/djsf.json
@@ -390,7 +390,7 @@
                             "title": "command",
 							"type":"object",
 							"description": "The parameters for the command. Parameters are command specific. So each command-type has different parameters.",
-							"anyOf":[
+							"oneOf":[
 								{ "$ref":"#/definitions/specialAnnouncementPossibleCommands/showDestination" },
 								{ "$ref":"#/definitions/specialAnnouncementPossibleCommands/enqueueFiles" },
 								{ "$ref":"#/definitions/specialAnnouncementPossibleCommands/showText" },


### PR DESCRIPTION
The online JSON viewer support only JSON Schema Draft 4 and higher. It would be nice, when it is possible to parse the JSON file directly from source.

## Changes
* Change schema URI
* Fix typos in `minItems`
* Add title property to each element
* Translate old `required` property to the new Draft version
* Fix superfluous square brackets arround `items`
* Remove square brackets from a single type
* Fix wrong `minItems` position from child to parent
* Add type to 'command'
* Fix $ref has to be a standalone property
* Fix commands.items to use 'oneOf' instead of 'anyOf'
* Making all 'specialAnnouncementPossibleCommand' to type enum

The last 2 changes are responsible for making the commands object work properly in the choosen schema viewer.

## Open questions
* Should `routeStationIdentifier` in `routeStations.items` be required?
* Should `command.params` be required?
* Should we really keep `minItems: 0`? It has no effect.
* What is the rule about spaces in this JSON Schema? Yes or No? I've seen both versions mixed.

## Tests
Here I will write how to test the JSON and the result.

## Screenshots
Params:
<img width="1001" height="590" alt="grafik" src="https://github.com/user-attachments/assets/cb973550-4e0f-4ff3-a48b-a2d0e94918a8" />

Special announcements --> commands:
<img width="932" height="470" alt="grafik" src="https://github.com/user-attachments/assets/51adf62d-85fb-4f2f-a329-7fb8a0039438" />

Allowed values for `travelOnDays`:
<img width="1029" height="75" alt="grafik" src="https://github.com/user-attachments/assets/1d93128f-28f6-4b04-9940-904d0ab341b5" />
